### PR TITLE
Clonable `NoticeError`

### DIFF
--- a/rumqttc/src/lib.rs
+++ b/rumqttc/src/lib.rs
@@ -167,7 +167,7 @@ use v5::mqttbytes::v5::{SubscribeReasonCode as V5SubscribeReasonCode,
                         UnsubAckReason,
                         PubAckReason, PubRecReason, PubCompReason};
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum NoticeError {
     #[error("Eventloop dropped Sender")]
     Recv,


### PR DESCRIPTION
Made the `NoticeError` clonable for extra portability